### PR TITLE
Rename test function to test_two_sum

### DIFF
--- a/leetcode/001-two-sum/test_twoSum.py
+++ b/leetcode/001-two-sum/test_twoSum.py
@@ -13,7 +13,7 @@ TEST_CASES = load_test_cases(__file__)
 
 
 @pytest.mark.parametrize("test_case", TEST_CASES, ids=[tc["id"] for tc in TEST_CASES])
-def test_two_sum_data_driven(test_case):
+def test_two_sum(test_case):
     """Data-driven test for Two Sum problem."""
     solution = Solution()
     result = solution.twoSum(test_case["input"]["nums"], test_case["input"]["target"])


### PR DESCRIPTION
## Summary
Rename `test_two_sum_data_driven` to `test_two_sum` for cleaner and simpler naming.

## Changes
- Function name: `test_two_sum_data_driven` → `test_two_sum`
- All functionality remains identical
- Test coverage unchanged

## Benefits
- **Cleaner naming**: Simpler function name without redundant "data_driven" suffix
- **Better pytest output**: Shorter, more readable test names in pytest results
- **Consistency**: Aligns with standard naming conventions

🤖 Generated with [Claude Code](https://claude.ai/code)